### PR TITLE
docs: fix blog post syntax errors

### DIFF
--- a/apps/docs/src/content/blog/ai-software-factory-en.md
+++ b/apps/docs/src/content/blog/ai-software-factory-en.md
@@ -1,5 +1,5 @@
 ---
-title: Assisted Software Engineering: The Antigravity Flow Architecture
+title: "Assisted Software Engineering: The Antigravity Flow Architecture"
 author: Architecture Team
 date: 2026-01-19
 readTime: 18 min
@@ -151,7 +151,7 @@ graph LR
     
     Browser -->|HTTPS Load| CDN
     CDN --> Static
-    Browser -->|HTTPS API Calls (CORS)| API
+    Browser -->|"HTTPS API Calls (CORS)"| API
     API -->|TCP Connection| DB
     
     style CDN fill:#000,stroke:#fff,color:#fff


### PR DESCRIPTION
Fixes YAML parser error due to unquoted colon in title, and Mermaid rendering error due to parens in label.